### PR TITLE
Added channel muting and volume control for basic interactivity.

### DIFF
--- a/js/ft2.js
+++ b/js/ft2.js
@@ -234,6 +234,9 @@ Fasttracker.prototype.initialize = function()
     this.channel[i].currentsample=0.0;
     this.channel[i].lastsample=0.0;
     this.channel[i].oldfinalvolume=0.0;
+
+    this.channel[i].interactiveMute = false;
+    this.channel[i].interactiveVolume = 1.0;
   }
 }
 
@@ -893,8 +896,10 @@ Fasttracker.prototype.mix = function(mod, bufs, buflen) {
           fr=fl*f;
           fl*=1.0-f;
         }
-        outp[0]+=fl;
-        outp[1]+=fr;
+        if (!mod.channel[ch].interactiveMute && mod.channel[ch].interactiveVolume > 0) {
+            outp[0]+=fl*mod.channel[ch].interactiveVolume;
+            outp[1]+=fr*mod.channel[ch].interactiveVolume;
+        }
 
         // advance sample position and check for loop or end
         var oldpos=mod.channel[ch].samplepos;

--- a/js/pt.js
+++ b/js/pt.js
@@ -163,6 +163,9 @@ Protracker.prototype.initialize = function()
     this.channel[i].vibratodepth=0
     this.channel[i].vibratopos=0;
     this.channel[i].vibratowave=0;
+
+    this.channel[i].interactiveMute = false;
+    this.channel[i].interactiveVolume = 1.0;
   }
 }
 
@@ -449,15 +452,17 @@ Protracker.prototype.mix = function(mod, bufs, buflen) {
         }
 
         // mix channel to output
-        och=och^(ch&1);
-        f=0.0;
-        if (mod.channel[ch].noteon) {
-          if (mod.sample[mod.channel[ch].sample].length > mod.channel[ch].samplepos)
-            f=(mod.sample[mod.channel[ch].sample].data[Math.floor(mod.channel[ch].samplepos)]*mod.channel[ch].volume)/64.0;
-          outp[och]+=f;
-          mod.channel[ch].samplepos+=mod.channel[ch].samplespeed;
+        if (!mod.channel[ch].interactiveMute && mod.channel[ch].interactiveVolume > 0) {
+            och=och^(ch&1);
+            f=0.0;
+            if (mod.channel[ch].noteon) {
+              if (mod.sample[mod.channel[ch].sample].length > mod.channel[ch].samplepos)
+                f=(mod.sample[mod.channel[ch].sample].data[Math.floor(mod.channel[ch].samplepos)]*mod.channel[ch].volume)/64.0*mod.channel[ch].interactiveVolume;
+              outp[och]+=f;
+              mod.channel[ch].samplepos+=mod.channel[ch].samplespeed;
+            }
+            mod.chvu[ch]=Math.max(mod.chvu[ch], Math.abs(f));
         }
-        mod.chvu[ch]=Math.max(mod.chvu[ch], Math.abs(f));
 
         // loop or end samples
         if (mod.channel[ch].noteon) {

--- a/js/st3.js
+++ b/js/st3.js
@@ -218,6 +218,9 @@ Screamtracker.prototype.initialize = function()
 
     this.channel[i].currentsample=0.0;
     this.channel[i].lastsample=0.0;
+
+    this.channel[i].interactiveMute = false;
+    this.channel[i].interactiveVolume = 1.0;
   }
 }
 
@@ -633,8 +636,10 @@ Screamtracker.prototype.mix = function(mod, bufs, buflen) {
           fr=fl*mod.pan_r[ch];
           fl*=mod.pan_l[ch];
         }
-        outp[0]+=fl;
-        outp[1]+=fr;
+        if (!mod.channel[ch].interactiveMute && mod.channel[ch].interactiveVolume > 0) {
+            outp[0]+=fl*mod.channel[ch].interactiveVolume;
+            outp[1]+=fr*mod.channel[ch].interactiveVolume;
+        }
 
         var oldpos=mod.channel[ch].samplepos;
         mod.channel[ch].samplepos+=mod.channel[ch].samplespeed;


### PR DESCRIPTION
I added two new fields to channels: `interactiveMute` and `interactiveVolume`.

The new fields allow this library to be used in an interactive, if simplistic, way.  By controlling how much presence different channels have, you can alter the music's effect.  This can be useful for interactive media, such as games.

Note - I gave the fields the prefix `interactive` to separate them from other channel fields, since these fields should NOT affect the song itself, just how it's rendered.  For example, you can change a channel's interactiveVolume from `1.0` to `0.5`, and any in-song volume changes will continue as normal, just quieter.